### PR TITLE
etcdmain: correctly check return values from SdNotify()

### DIFF
--- a/clientv3/integration/watch_test.go
+++ b/clientv3/integration/watch_test.go
@@ -400,7 +400,7 @@ func TestWatchResumeCompacted(t *testing.T) {
 func TestWatchCompactRevision(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer clus.Terminate(t)
 
 	// set some keys

--- a/cmd/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
+++ b/cmd/vendor/github.com/coreos/go-systemd/daemon/sdnotify.go
@@ -2,30 +2,37 @@
 package daemon
 
 import (
-	"errors"
 	"net"
 	"os"
 )
 
-var SdNotifyNoSocket = errors.New("No socket")
-
 // SdNotify sends a message to the init daemon. It is common to ignore the error.
-func SdNotify(state string) error {
+// It returns one of the following:
+// (false, nil) - notification not supported (i.e. NOTIFY_SOCKET is unset)
+// (false, err) - notification supported, but failure happened (e.g. error connecting to NOTIFY_SOCKET or while sending data)
+// (true, nil) - notification supported, data has been sent
+func SdNotify(state string) (sent bool, err error) {
 	socketAddr := &net.UnixAddr{
 		Name: os.Getenv("NOTIFY_SOCKET"),
 		Net:  "unixgram",
 	}
 
+	// NOTIFY_SOCKET not set
 	if socketAddr.Name == "" {
-		return SdNotifyNoSocket
+		return false, nil
 	}
 
 	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	// Error connecting to NOTIFY_SOCKET
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer conn.Close()
 
 	_, err = conn.Write([]byte(state))
-	return err
+	// Error sending the message
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/etcdmain/etcd.go
+++ b/etcdmain/etcd.go
@@ -160,12 +160,12 @@ func startEtcdOrProxyV2() {
 		// for accepting connections. The etcd instance should be
 		// joined with the cluster and ready to serve incoming
 		// connections.
-		err := daemon.SdNotify("READY=1")
+		sent, err := daemon.SdNotify("READY=1")
 		if err != nil {
 			plog.Errorf("failed to notify systemd for readiness: %v", err)
-			if err == daemon.SdNotifyNoSocket {
-				plog.Errorf("forgot to set Type=notify in systemd service file?")
-			}
+		}
+		if !sent {
+			plog.Errorf("forgot to set Type=notify in systemd service file?")
 		}
 	}
 

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1357,9 +1357,10 @@ func (n *nodeRecorder) Step(ctx context.Context, msg raftpb.Message) error {
 	n.Record(testutil.Action{Name: "Step"})
 	return nil
 }
-func (n *nodeRecorder) Status() raft.Status      { return raft.Status{} }
-func (n *nodeRecorder) Ready() <-chan raft.Ready { return nil }
-func (n *nodeRecorder) Advance()                 {}
+func (n *nodeRecorder) Status() raft.Status                              { return raft.Status{} }
+func (n *nodeRecorder) Ready() <-chan raft.Ready                         { return nil }
+func (n *nodeRecorder) ReadIndex(ctx context.Context, rctx []byte) error { return nil }
+func (n *nodeRecorder) Advance()                                         {}
 func (n *nodeRecorder) ApplyConfChange(conf raftpb.ConfChange) *raftpb.ConfState {
 	n.Record(testutil.Action{Name: "ApplyConfChange", Params: []interface{}{conf}})
 	return &raftpb.ConfState{}

--- a/pkg/transport/listener.go
+++ b/pkg/transport/listener.go
@@ -34,27 +34,30 @@ import (
 	"github.com/coreos/etcd/pkg/tlsutil"
 )
 
-func NewListener(addr string, scheme string, tlscfg *tls.Config) (l net.Listener, err error) {
-	if scheme == "unix" || scheme == "unixs" {
-		// unix sockets via unix://laddr
-		l, err = NewUnixListener(addr)
-	} else {
-		l, err = net.Listen("tcp", addr)
-	}
-
-	if err != nil {
+func NewListener(addr, scheme string, tlscfg *tls.Config) (l net.Listener, err error) {
+	if l, err = newListener(addr, scheme); err != nil {
 		return nil, err
 	}
+	return wrapTLS(addr, scheme, tlscfg, l)
+}
 
-	if scheme == "https" || scheme == "unixs" {
-		if tlscfg == nil {
-			return nil, fmt.Errorf("cannot listen on TLS for %s: KeyFile and CertFile are not presented", scheme+"://"+addr)
-		}
-
-		l = tls.NewListener(l, tlscfg)
+func newListener(addr string, scheme string) (net.Listener, error) {
+	if scheme == "unix" || scheme == "unixs" {
+		// unix sockets via unix://laddr
+		return NewUnixListener(addr)
 	}
+	return net.Listen("tcp", addr)
+}
 
-	return l, nil
+func wrapTLS(addr, scheme string, tlscfg *tls.Config, l net.Listener) (net.Listener, error) {
+	if scheme != "https" && scheme != "unixs" {
+		return l, nil
+	}
+	if tlscfg == nil {
+		l.Close()
+		return nil, fmt.Errorf("cannot listen on TLS for %s: KeyFile and CertFile are not presented", scheme+"://"+addr)
+	}
+	return tls.NewListener(l, tlscfg), nil
 }
 
 type TLSInfo struct {

--- a/pkg/transport/timeout_listener.go
+++ b/pkg/transport/timeout_listener.go
@@ -24,15 +24,19 @@ import (
 // If read/write on the accepted connection blocks longer than its time limit,
 // it will return timeout error.
 func NewTimeoutListener(addr string, scheme string, tlscfg *tls.Config, rdtimeoutd, wtimeoutd time.Duration) (net.Listener, error) {
-	ln, err := NewListener(addr, scheme, tlscfg)
+	ln, err := newListener(addr, scheme)
 	if err != nil {
 		return nil, err
 	}
-	return &rwTimeoutListener{
+	ln = &rwTimeoutListener{
 		Listener:   ln,
 		rdtimeoutd: rdtimeoutd,
 		wtimeoutd:  wtimeoutd,
-	}, nil
+	}
+	if ln, err = wrapTLS(addr, scheme, tlscfg, ln); err != nil {
+		return nil, err
+	}
+	return ln, nil
 }
 
 type rwTimeoutListener struct {

--- a/proxy/grpcproxy/watcher_groups.go
+++ b/proxy/grpcproxy/watcher_groups.go
@@ -69,7 +69,7 @@ func (wgs *watchergroups) maybeJoinWatcherSingle(rid receiverID, ws watcherSingl
 
 	gropu, ok := wgs.groups[ws.w.wr]
 	if ok {
-		if ws.rev >= gropu.rev {
+		if ws.w.rev >= gropu.rev {
 			gropu.add(receiverID{streamID: ws.sws.id, watcherID: ws.w.id}, ws.w)
 			return true
 		}

--- a/raft/node.go
+++ b/raft/node.go
@@ -157,6 +157,18 @@ type Node interface {
 	// in snapshots. Will never return nil; it returns a pointer only
 	// to match MemoryStorage.Compact.
 	ApplyConfChange(cc pb.ConfChange) *pb.ConfState
+
+	// ReadIndex request a read state. The read state will be set in the ready.
+	// Read state has a read index. Once the application advances further than the read
+	// index, any linearizable read requests issued before the read request can be
+	// processed safely. The read state will have the same rctx attached.
+	//
+	// Note: the current implementation depends on the leader lease. If the clock drift is unbounded,
+	// leader might keep the lease longer than it should (clock can move backward/pause without any bound).
+	// ReadIndex is not safe in that case.
+	// TODO: add clock drift bound into raft configuration.
+	ReadIndex(ctx context.Context, rctx []byte) error
+
 	// Status returns the current status of the raft state machine.
 	Status() Status
 	// ReportUnreachable reports the given node is not reachable for the last send.
@@ -487,8 +499,8 @@ func (n *node) ReportSnapshot(id uint64, status SnapshotStatus) {
 	}
 }
 
-func (n *node) ReadIndex(ctx context.Context, id uint64, rctx []byte) error {
-	return n.step(ctx, pb.Message{Type: pb.MsgReadIndex, From: id, Entries: []pb.Entry{{Data: rctx}}})
+func (n *node) ReadIndex(ctx context.Context, rctx []byte) error {
+	return n.step(ctx, pb.Message{Type: pb.MsgReadIndex, Entries: []pb.Entry{{Data: rctx}}})
 }
 
 func newReady(r *raft, prevSoftSt *SoftState, prevHardSt pb.HardState) Ready {

--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -180,7 +180,7 @@ func TestNodeReadIndex(t *testing.T) {
 
 	r.step = appendStep
 	wrequestCtx = []byte("somedata2")
-	n.ReadIndex(context.TODO(), r.id, wrequestCtx)
+	n.ReadIndex(context.TODO(), wrequestCtx)
 	n.Stop()
 
 	if len(msgs) != 1 {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -681,8 +681,12 @@ func stepLeader(r *raft, m pb.Message) {
 		if r.checkQuorum {
 			ri = r.raftLog.committed
 		}
-
-		r.send(pb.Message{To: m.From, Type: pb.MsgReadIndexResp, Index: ri, Entries: m.Entries})
+		if m.From == None || m.From == r.id { // from local member
+			r.readState.Index = ri
+			r.readState.RequestCtx = m.Entries[0].Data
+		} else {
+			r.send(pb.Message{To: m.From, Type: pb.MsgReadIndexResp, Index: ri, Entries: m.Entries})
+		}
 		return
 	}
 


### PR DESCRIPTION
Since https://github.com/coreos/go-systemd/commit/0d7fccc155921b2b4023b0acfd60981d4a27b3da, `SdNotify()` in `go-systemd` started to return 2 values, sent and err. So `startEtcdOrProxyV2()` in etcd needs to check the 2 return values correctly. As the 2 values are independent of each other, error checking logic needs to be slightly updated too. `SdNotifyNoSocket`, which was previously provided by `go-systemd`, does not exist any more. In that case `(false, nil)` will be returned instead.

This was a direct reason of a travis-ci failure in fleet like this: https://travis-ci.org/coreos/fleet/builds/146093283. Although fleet has nothing to do with this API change, travis always fetches the most recent master branch for each git repo.
